### PR TITLE
BugFix in redBlackBst implmentation

### DIFF
--- a/redblackbst.go
+++ b/redblackbst.go
@@ -502,6 +502,10 @@ func (t *redBlackBST) deleteMin(n *nodeRedBlack) *nodeRedBlack {
 			t.minC = next
 		}
 
+		if t.maxC == n {
+			t.maxC = prev
+		}
+
 		return n.right
 	}
 


### PR DESCRIPTION
**Scenario:** Deletion of the Largest Key

**Issue:** After largest key deletion all next/pre queries on t.maxC gives nil pointer

**What's Happening:**
When a largest node is removed from the tree due to the deletion operation, the tree is correctly updated. However, the `t.maxC` node still points to the deleted node, causing all queries of `Next` or `Previous` from `t.maxC` to result in a nil pointer.